### PR TITLE
added transferWithAuthorization to deposit USDC

### DIFF
--- a/contracts/interfaces/IEIP3009.sol
+++ b/contracts/interfaces/IEIP3009.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.6.0) (token/ERC20/IERC20.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IEIP3009 {
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
+
+    /**
+     * @notice Execute a transfer with a signed authorization
+     * @param from          Payer's address (Authorizer)
+     * @param to            Payee's address
+     * @param value         Amount to be transferred
+     * @param validAfter    The time after which this is valid (unix time)
+     * @param validBefore   The time before which this is valid (unix time)
+     * @param nonce         Unique nonce
+     * @param v             v of the signature
+     * @param r             r of the signature
+     * @param s             s of the signature
+     */
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    /**
+     * @notice Receive a transfer with a signed authorization from the payer
+     * @dev This has an additional check to ensure that the payee's address matches
+     * the caller of this function to prevent front-running attacks. (See security
+     * considerations)
+     * @param from          Payer's address (Authorizer)
+     * @param to            Payee's address
+     * @param value         Amount to be transferred
+     * @param validAfter    The time after which this is valid (unix time)
+     * @param validBefore   The time before which this is valid (unix time)
+     * @param nonce         Unique nonce
+     * @param v             v of the signature
+     * @param r             r of the signature
+     * @param s             s of the signature
+     */
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}


### PR DESCRIPTION
I deployed a test contract to polygon and verified that it received the new USDC. Contract address is 0xf5f248986e010191cF2cf06Dae80dDE7f1090832

and here is the test contract solidity...

//SPDX-License-Identifier: Unlicense
pragma solidity ^0.8.9;

import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
import "./IEIP3009.sol";

contract TestUsdc {

  struct UsdcTransfer {
    address from;
    address to;
    uint256 value;
    uint256 validAfter;
    uint256 validBefore;
    bytes32 nonce;
    uint8 v;
    bytes32 r;
    bytes32 s;
  }

  address constant private USDC_TOKEN = 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359;

  function deposit(UsdcTransfer calldata usdcTransfer) external {
    require(usdcTransfer.to == address(this), "USDC_TO");
    require(usdcTransfer.from == msg.sender, "USDC_FROM");
    uint balance = IERC20(USDC_TOKEN).balanceOf(address(this));
    IEIP3009(USDC_TOKEN).transferWithAuthorization(usdcTransfer.from, usdcTransfer.to, usdcTransfer.value, usdcTransfer.validAfter, usdcTransfer.validBefore, usdcTransfer.nonce, usdcTransfer.v, usdcTransfer.r, usdcTransfer.s);
    require(balance + usdcTransfer.value == IERC20(USDC_TOKEN).balanceOf(address(this)), "USDC_TRANSFER");
  }
}

Also here is my test script code if it helps...

  async function testClicked() {
    const transferUsdc = {
      from: account,
      to: "0xf5f248986e010191cF2cf06Dae80dDE7f1090832",
      value: ethers.utils.parseUnits("1.0", 6),
      validAfter: 0,
      validBefore: Math.floor(Date.now() / 1000) + 60 * 60,
      nonce: ethers.utils.keccak256(ethers.utils.randomBytes(32)),
    } as UsdcTransferStruct;

    const data = {
      types: {
        EIP712Domain: [
          { name: "name", type: "string" },
          { name: "version", type: "string" },
          { name: "chainId", type: "uint256" },
          { name: "verifyingContract", type: "address" },
        ],
        TransferWithAuthorization: [
          { name: "from", type: "address" },
          { name: "to", type: "address" },
          { name: "value", type: "uint256" },
          { name: "validAfter", type: "uint256" },
          { name: "validBefore", type: "uint256" },
          { name: "nonce", type: "bytes32" },
        ],
      },
      domain: {
        name: "USD Coin",
        version: "2",
        chainId: 137,
        verifyingContract: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
      },
      primaryType: "TransferWithAuthorization",
      message: {
        from: transferUsdc.from,
        to: transferUsdc.to,
        value: transferUsdc.value.toString(),
        validAfter: transferUsdc.validAfter,
        validBefore: transferUsdc.validBefore,
        nonce: transferUsdc.nonce,
      },
    };

    const signature = await window?.ethereum.request({
      method: "eth_signTypedData_v4",
      params: [account, JSON.stringify(data)],
    });

    transferUsdc.v = "0x" + signature.slice(130, 132);
    transferUsdc.r = signature.slice(0, 66);
    transferUsdc.s = "0x" + signature.slice(66, 130);

    // Call the deposit function
    await testUsdc.deposit(transferUsdc);
  }

